### PR TITLE
Fix macOS dependency syntax in susops.rb

### DIFF
--- a/Casks/susops.rb
+++ b/Casks/susops.rb
@@ -13,7 +13,7 @@ cask "susops" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: :big_sur
   depends_on arch: :arm64
   # socat is required for UDP port forwarding (core/socat.py shells out to it);
   # the bundled .app can't ship a system binary, so pull it as a hard dep.


### PR DESCRIPTION
Fixes warning when upgrading. 

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :big_sur` instead.
Please report this issue to the mashb1t/homebrew-susops tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/mashb1t/homebrew-susops/Casks/susops.rb:16
```