### PR TITLE
Update pydantic-core resource URL and checksum

### DIFF
--- a/Formula/susops.rb
+++ b/Formula/susops.rb
@@ -120,8 +120,8 @@ class Susops < Formula
   end
 
   resource "pydantic-core" do
-    url "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz"
-    sha256 "08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e"
+    url "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz"
+    sha256 "41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c"
   end
 
   resource "pygments" do


### PR DESCRIPTION
Fixes dependency so can be installed. 

https://github.com/mashb1t/susops/issues/8#issuecomment-5133280616

The uv.lock upstream [has the correct version](https://github.com/mashb1t/susops/blob/main/uv.lock#L1058), not sure why it didn't propagate correctly. 

This will probably break again on the next release unless I can figure out why the uv.lock isn't being respected. 